### PR TITLE
Fix/spinner

### DIFF
--- a/src/js/components/hero.js
+++ b/src/js/components/hero.js
@@ -2,6 +2,7 @@ import markUpFilms from './markUpFilms';
 import { getTrendingMovies } from '../services/API';
 import { onCardsSelect } from './card-modal';
 import { makePagesMarkup, onPageBtnsSelect, getPageNum } from './on-pagination-trending';
+import { showSpinner, hideSpinner } from './spinner';
 
 export const refs = {
   imagesList: document.querySelector('.films-list'),
@@ -22,12 +23,15 @@ pushFetch();
 
 export function pushFetch() {
   try {
+    showSpinner();
     const response = getTrendingMovies(pageNum);
     sessionStorage.setItem('calculatedPageNum', pageNum);
     return response.then(({ data }) => {
       markUp(data);
+      hideSpinner();
     });
   } catch (error) {
+    hideSpinner();
     console.log(error);
   }
 }


### PR DESCRIPTION
Додав спінер при натисканні на лого та хоум. Раніше спінер на ці кнопки не додавав, бо вважаю не правильним, що йдуть повторно нові запроси. Я б відмальовував лого та хоум з локалстор. При переході на попередню та наступну сторінки спінер до асинхронної операції доданий, тільки він відображається на час очікування відповіді від серверу. Після відповіді з сервера спінер зникає і починає відмальовуватися сторінка. Якщо залишити спінер на час відмальовки сторінки, то тоді клієнту треба буде чекати повної відмальовки всіх 20-ти фільмів, а не тільки перших в полі зору. На хоум та лого спінер також додав на час очікування відповіді від сервера.